### PR TITLE
Ask for a Display Name

### DIFF
--- a/oShare.xcodeproj/project.pbxproj
+++ b/oShare.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		063D1E5B1FEF3CCC001A6DC4 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063D1E5A1FEF3CCC001A6DC4 /* Constants.swift */; };
 		063D1E5D1FEF3E0D001A6DC4 /* MultipeerConnectivityManagerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063D1E5C1FEF3E0D001A6DC4 /* MultipeerConnectivityManagerDelegate.swift */; };
 		063D1E611FEF6FC4001A6DC4 /* PeerBrowserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063D1E601FEF6FC4001A6DC4 /* PeerBrowserViewController.swift */; };
+		063D1E631FF10F24001A6DC4 /* SheetAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063D1E621FF10F24001A6DC4 /* SheetAnimator.swift */; };
+		063D1E651FF11ED7001A6DC4 /* CharacterCounterTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063D1E641FF11ED7001A6DC4 /* CharacterCounterTextField.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -48,6 +50,8 @@
 		063D1E5A1FEF3CCC001A6DC4 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		063D1E5C1FEF3E0D001A6DC4 /* MultipeerConnectivityManagerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipeerConnectivityManagerDelegate.swift; sourceTree = "<group>"; };
 		063D1E601FEF6FC4001A6DC4 /* PeerBrowserViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerBrowserViewController.swift; sourceTree = "<group>"; };
+		063D1E621FF10F24001A6DC4 /* SheetAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetAnimator.swift; sourceTree = "<group>"; };
+		063D1E641FF11ED7001A6DC4 /* CharacterCounterTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterCounterTextField.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -92,6 +96,7 @@
 			isa = PBXGroup;
 			children = (
 				063D1E331FEF33FF001A6DC4 /* AppDelegate.swift */,
+				063D1E641FF11ED7001A6DC4 /* CharacterCounterTextField.swift */,
 				063D1E351FEF33FF001A6DC4 /* ChatSetupViewController.swift */,
 				063D1E601FEF6FC4001A6DC4 /* PeerBrowserViewController.swift */,
 				063D1E371FEF33FF001A6DC4 /* Main.storyboard */,
@@ -102,6 +107,7 @@
 				063D1E5C1FEF3E0D001A6DC4 /* MultipeerConnectivityManagerDelegate.swift */,
 				063D1E581FEF3C43001A6DC4 /* MultipeerConnectivityError.swift */,
 				063D1E5A1FEF3CCC001A6DC4 /* Constants.swift */,
+				063D1E621FF10F24001A6DC4 /* SheetAnimator.swift */,
 			);
 			path = oShare;
 			sourceTree = "<group>";
@@ -226,12 +232,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				063D1E651FF11ED7001A6DC4 /* CharacterCounterTextField.swift in Sources */,
 				063D1E611FEF6FC4001A6DC4 /* PeerBrowserViewController.swift in Sources */,
 				063D1E5B1FEF3CCC001A6DC4 /* Constants.swift in Sources */,
 				063D1E361FEF33FF001A6DC4 /* ChatSetupViewController.swift in Sources */,
 				063D1E341FEF33FF001A6DC4 /* AppDelegate.swift in Sources */,
 				063D1E5D1FEF3E0D001A6DC4 /* MultipeerConnectivityManagerDelegate.swift in Sources */,
 				063D1E591FEF3C43001A6DC4 /* MultipeerConnectivityError.swift in Sources */,
+				063D1E631FF10F24001A6DC4 /* SheetAnimator.swift in Sources */,
 				063D1E571FEF34A9001A6DC4 /* MultipeerConnectivityManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/oShare/AppDelegate.swift
+++ b/oShare/AppDelegate.swift
@@ -1,11 +1,3 @@
-//
-//  AppDelegate.swift
-//  oShare
-//
-//  Created by Ben Deckys on 24/12/17.
-//  Copyright © 2017 MIMIMI. All rights reserved.
-//
-
 import UIKit
 
 @UIApplicationMain

--- a/oShare/Base.lproj/Main.storyboard
+++ b/oShare/Base.lproj/Main.storyboard
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" systemVersion="17A277" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Peer Browser View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="PeerBrowserViewController" customModule="oShare" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -19,6 +22,75 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+        </scene>
+        <!--Chat Setup View Controller-->
+        <scene sceneID="uYE-Xl-fo7">
+            <objects>
+                <viewController storyboardIdentifier="setupViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="feJ-YO-FFf" customClass="ChatSetupViewController" customModule="oShare" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="uPr-jz-wBm">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <navigationBar contentMode="scaleToFill" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XXo-Ww-8Nu">
+                                <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="mG5-6X-dag"/>
+                                </constraints>
+                                <items>
+                                    <navigationItem title="Set a Display Name" id="OmQ-vL-flT">
+                                        <barButtonItem key="rightBarButtonItem" title="Save" style="plain" id="1w9-ZM-hRZ">
+                                            <connections>
+                                                <action selector="saveDisplayNameWithSender:" destination="feJ-YO-FFf" id="VGA-4A-Vfk"/>
+                                            </connections>
+                                        </barButtonItem>
+                                    </navigationItem>
+                                </items>
+                            </navigationBar>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2gU-0f-q0L" customClass="CharacterCounterTextField" customModule="oShare" customModuleProvider="target">
+                                <rect key="frame" x="20" y="176" width="335" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="jCG-3M-kzM"/>
+                                </constraints>
+                                <nil key="textColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="characterLimit">
+                                        <integer key="value" value="20"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </textField>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Psc-uX-QMo">
+                                <rect key="frame" x="20" y="84" width="335" height="72"/>
+                                <string key="text">Please choose a Display Name. This name cannot be empty, nor can it be greater than 20 characters in length. This name will be used to identify you to devices in the vicinity.</string>
+                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="NaD-GH-ihZ" firstAttribute="trailing" secondItem="Psc-uX-QMo" secondAttribute="trailing" constant="20" id="11C-JA-NHX"/>
+                            <constraint firstItem="2gU-0f-q0L" firstAttribute="top" secondItem="Psc-uX-QMo" secondAttribute="bottom" constant="20" id="3AH-Xl-fbN"/>
+                            <constraint firstItem="Psc-uX-QMo" firstAttribute="top" secondItem="XXo-Ww-8Nu" secondAttribute="bottom" constant="20" id="49U-4J-PhX"/>
+                            <constraint firstItem="XXo-Ww-8Nu" firstAttribute="top" secondItem="NaD-GH-ihZ" secondAttribute="top" id="722-tg-usx"/>
+                            <constraint firstItem="NaD-GH-ihZ" firstAttribute="bottom" secondItem="2gU-0f-q0L" secondAttribute="bottom" priority="250" constant="20" id="C2N-Wx-Zma"/>
+                            <constraint firstItem="NaD-GH-ihZ" firstAttribute="trailing" secondItem="2gU-0f-q0L" secondAttribute="trailing" constant="20" id="J4v-dW-zCE"/>
+                            <constraint firstItem="XXo-Ww-8Nu" firstAttribute="leading" secondItem="NaD-GH-ihZ" secondAttribute="leading" id="TZy-hw-pv2"/>
+                            <constraint firstItem="XXo-Ww-8Nu" firstAttribute="trailing" secondItem="NaD-GH-ihZ" secondAttribute="trailing" id="UfW-oi-tnc"/>
+                            <constraint firstItem="2gU-0f-q0L" firstAttribute="leading" secondItem="NaD-GH-ihZ" secondAttribute="leading" constant="20" id="cLD-nU-jqv"/>
+                            <constraint firstItem="Psc-uX-QMo" firstAttribute="leading" secondItem="NaD-GH-ihZ" secondAttribute="leading" constant="20" id="eKx-4m-MeE"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="NaD-GH-ihZ"/>
+                    </view>
+                    <connections>
+                        <outlet property="continueButton" destination="1w9-ZM-hRZ" id="yJJ-we-swa"/>
+                        <outlet property="displayNameTextField" destination="2gU-0f-q0L" id="QUc-tN-7zp"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="F4b-BC-acw" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1348" y="34"/>
         </scene>
     </scenes>
 </document>

--- a/oShare/CharacterCounterTextField.swift
+++ b/oShare/CharacterCounterTextField.swift
@@ -6,6 +6,8 @@ import UIKit
 	@IBInspectable var characterLimit: Int = 20
 	
 	private let characterCountLabel = UILabel()
+	private let characterCountLabelSize: CGSize = CGSize(width: 30, height: 30)
+	private let characterCountLabelXOffset: CGFloat = 35
 	
 	override func awakeFromNib() {
 		super.awakeFromNib()
@@ -36,8 +38,10 @@ import UIKit
 	
 	override func rightViewRect(forBounds bounds: CGRect) -> CGRect {
 		if characterLimit > 0 {
-			return CGRect(x: frame.width-35, y: 0, width: 30, height:
-				30)
+			return CGRect(
+				origin: CGPoint(x: frame.width-characterCountLabelXOffset, y: 0),
+				size: characterCountLabelSize
+			)
 		} else {
 			return CGRect()
 		}

--- a/oShare/CharacterCounterTextField.swift
+++ b/oShare/CharacterCounterTextField.swift
@@ -1,0 +1,45 @@
+import Foundation
+import UIKit
+
+@IBDesignable class CharacterCounterTextField: UITextField {
+	
+	@IBInspectable var characterLimit: Int = 20
+	
+	private let characterCountLabel = UILabel()
+	
+	override func awakeFromNib() {
+		super.awakeFromNib()
+		
+		if characterLimit > 0 {
+			setCountLabel()
+		}
+	}
+	
+	private func setCountLabel() {
+		characterCountLabel.font = UIFont.systemFont(ofSize: 12, weight: .semibold)
+		characterCountLabel.textAlignment = .center
+		characterCountLabel.text = "0"
+		
+		rightView = characterCountLabel
+		rightViewMode = .always
+	}
+	
+	func updateWith(count: Int) {
+		characterCountLabel.text = "\(count)"
+		
+		if count > Constants.Numbers.maximumDisplayNameLength || count == 0 {
+			characterCountLabel.textColor = .red
+		} else {
+			characterCountLabel.textColor = .black
+		}
+	}
+	
+	override func rightViewRect(forBounds bounds: CGRect) -> CGRect {
+		if characterLimit > 0 {
+			return CGRect(x: frame.width-35, y: 0, width: 30, height:
+				30)
+		} else {
+			return CGRect()
+		}
+	}
+}

--- a/oShare/ChatSetupViewController.swift
+++ b/oShare/ChatSetupViewController.swift
@@ -1,34 +1,102 @@
 import UIKit
 
+/// A simple protocol, in the form of a delegate, to pass along a notification when this view controller is dismissed to its parent. This is because its `next` UIResponder is `nil`.
+protocol ChatSetupViewControllerDelegate: class {
+	func dismissed()
+}
+
 class ChatSetupViewController: UIViewController {
 
-	// As per recent WWDC sessions, IBOutlet properties should be `strong`. I generally prefer to keep them `weak` as old habits die hard.
-	@IBOutlet var displayNameTextField: UITextField!
-	@IBOutlet var displayNameCharacterCountLabel: UILabel!
-	@IBOutlet var continueButton: UIButton!
+	// As per recent WWDC sessions, IBOutlet properties should be `strong`. I generally prefer to keep them `weak` as old habits die hard, however for standards sake, I'll keep them strong.
+	@IBOutlet var displayNameTextField: CharacterCounterTextField!
+	@IBOutlet var continueButton: UIBarButtonItem!
+	
+	weak var delegate: ChatSetupViewControllerDelegate?
+	
+	required init?(coder aDecoder: NSCoder) {
+		super.init(coder: aDecoder)
+		
+		modalPresentationStyle = .overCurrentContext
+	}
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
+
+		registerKeyboardNotifications()
+		configureSaveButton()
+		configureTextField()
+	}
+	
+	override func viewWillDisappear(_ animated: Bool) {
+		super.viewWillDisappear(animated)
 		
+		NotificationCenter.default.removeObserver(self)
+	}
+	
+	private func configureSaveButton() {
+		continueButton.isEnabled = false
+	}
+	
+	private func configureTextField() {
 		displayNameTextField.delegate = self
+		displayNameTextField.becomeFirstResponder()
+		displayNameTextField.updateWith(count: 0)
+		
+		if let displayName = UserDefaults.standard.value(forKey: "displayName") as? String {
+			displayNameTextField.text = displayName
+			displayNameTextField.updateWith(count: displayName.count)
+			continueButton.isEnabled = true
+		}
+	}
+	
+	private func registerKeyboardNotifications() {
+		NotificationCenter.default.addObserver(self, selector: #selector(ChatSetupViewController.adjustForDisplayKeyboard(_:)), name: NSNotification.Name.UIKeyboardWillShow, object: nil)
+
+		NotificationCenter.default.addObserver(self, selector: #selector(ChatSetupViewController.adjustForHideKeyboard(_:)), name: NSNotification.Name.UIKeyboardWillHide, object: nil)
+	}
+	
+	@objc private func adjustForDisplayKeyboard(_ notification: Notification) {
+		if let keyboardSize = notification.userInfo?[UIKeyboardFrameEndUserInfoKey] as? CGRect {
+			UIView.animate(withDuration: 0.5) { [weak self] in
+				guard let strongSelf = self else { return }
+				strongSelf.view.frame.origin.y = keyboardSize.origin.y - strongSelf.view.frame.size.height
+			}
+		}
+	}
+	
+	@objc private func adjustForHideKeyboard(_ notification: Notification) {
+			UIView.animate(withDuration: 0.5) { [weak self] in
+				guard let strongSelf = self else { return }
+				strongSelf.view.frame.origin.y = UIScreen.main.bounds.size.height-strongSelf.view.frame.size.height
+			}
 	}
 	
 	@IBAction private func saveDisplayName(sender: UIButton) {
+		guard let displayName = displayNameTextField.text, displayNameTextField.text?.isEmpty == false else { return }
 		
+		UserDefaults.standard.set(displayName, forKey: "displayName")
+		
+		dismiss(animated: true, completion: { [weak self] in
+			self?.delegate?.dismissed()
+		})
 	}
 	
 	private func updateCharacterCountLabel(withCount count: Int) {
 		// The MCPeerID documentation states that the hard limit for display names is 63 bytes in UTF-8 encoding. I could set the limit to 63 characters, however a user may be partial to using Emoji, or may use a language such as 日本語, which characters have a variable byte length. 20 seems like a safe value here.
 		
-		continueButton.isEnabled = count <= 20
-		displayNameCharacterCountLabel.textColor = count > 20 ? .red : .black
+		continueButton.isEnabled = count <= Constants.Numbers.maximumDisplayNameLength && count > 0
+		displayNameTextField.updateWith(count: count)
 	}
 	
 }
 
 extension ChatSetupViewController: UITextFieldDelegate {
 	func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-		updateCharacterCountLabel(withCount: string.count)
+		guard let text = textField.text else { return true }
+		
+		let newLength = text.utf16.count + string.utf16.count - range.length
+		
+		updateCharacterCountLabel(withCount: newLength)
 		
 		return true
 	}

--- a/oShare/Constants.swift
+++ b/oShare/Constants.swift
@@ -1,5 +1,27 @@
+import UIKit
+
 struct Constants {
+	
+	static let mainStoryboard: UIStoryboard = UIStoryboard(name: "Main", bundle: nil)
+	static let mainWindow: UIWindow? = UIApplication.shared.keyWindow
+	
 	struct Strings {
 		static let serviceType: String = "oshare-chat"
 	}
+	
+	struct Numbers {
+		static let maximumDisplayNameLength: Int = 20
+		static let displayNamePopoverTransitionDuration: Double = 0.5
+		static let displayNamePopoverHeight: CGFloat = 300
+		
+		// MARK: - Safe Area Insets
+		// These properties will be 0 on non-iPhone X devices, and devices not running iOS 11.
+		
+		/// Inset to account for the presence of the "Sensor Housing" aka "Notch" on the iPhone X.
+		static let notchInset: CGFloat = Constants.mainWindow?.safeAreaInsets.top ?? 0
+		
+		/// Inset to account for the presence of the "Home Indicator" on the iPhone X.
+		static let homeIndicatorInset: CGFloat = Constants.mainWindow?.safeAreaInsets.bottom ?? 0
+	}
+	
 }

--- a/oShare/PeerBrowserViewController.swift
+++ b/oShare/PeerBrowserViewController.swift
@@ -5,9 +5,47 @@ class PeerBrowserViewController: UIViewController {
 	@IBOutlet var peerTableView: UITableView!
 	@IBOutlet var discoverabilitySwitch: UISwitch!
 	
+	private let transitionAnimator = SheetAnimator()
+	
 	override func viewDidLoad() {
 		super.viewDidLoad()
-		
 	}
 	
+	override func viewDidAppear(_ animated: Bool) {
+		super.viewDidAppear(animated)
+		checkDisplayName()
+	}
+	
+	private func checkDisplayName() {
+		guard let setupViewController = Constants.mainStoryboard.instantiateViewController(withIdentifier: "setupViewController") as? ChatSetupViewController else { return }
+		setupViewController.transitioningDelegate = self
+		setupViewController.delegate = self
+		
+		UIView.animate(withDuration: 0.5, animations: { [weak self] in
+			self?.view.alpha = 0.6
+		})
+		
+		present(setupViewController, animated: true, completion: nil)
+	}
+	
+}
+
+extension PeerBrowserViewController: UIViewControllerTransitioningDelegate {
+	func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+		transitionAnimator.isPresenting = true
+		return transitionAnimator
+	}
+	
+	func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+		transitionAnimator.isPresenting = false
+		return transitionAnimator
+	}
+}
+
+extension PeerBrowserViewController: ChatSetupViewControllerDelegate {
+	func dismissed() {
+		UIView.animate(withDuration: 0.5, animations: { [weak self] in
+			self?.view.alpha = 1.0
+		})
+	}
 }

--- a/oShare/SheetAnimator.swift
+++ b/oShare/SheetAnimator.swift
@@ -1,0 +1,49 @@
+import UIKit
+import Foundation
+
+class SheetAnimator: NSObject, UIViewControllerAnimatedTransitioning {
+	
+	var isPresenting = true
+	
+	private var homeInset = Constants.Numbers.homeIndicatorInset
+	private var popoverHeight: CGFloat = 0
+	private var originFrame = CGRect(
+		x: 0,
+		y: UIScreen.main.bounds.size.height,
+		width: UIScreen.main.bounds.size.width,
+		height: Constants.Numbers.displayNamePopoverHeight
+	)
+	
+	func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+		return Constants.Numbers.displayNamePopoverTransitionDuration
+	}
+	
+	func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+		let containerView = transitionContext.containerView
+		
+		// We want to ensure we actually have a destination.
+		guard let sheetView = isPresenting ? transitionContext.view(forKey: .to) : transitionContext.view(forKey: .from) else { return }
+		
+		popoverHeight = sheetView.systemLayoutSizeFitting(CGSize(width: UIScreen.main.bounds.size.width, height: 100), withHorizontalFittingPriority: .required, verticalFittingPriority: .defaultLow).height
+		
+		sheetView.frame.size.height = popoverHeight
+		
+		if isPresenting {
+			sheetView.frame.origin.y = originFrame.origin.y
+		}
+
+		containerView.addSubview(sheetView)
+		
+		UIView.animate(withDuration: transitionDuration(using: transitionContext), animations: { [weak self] in
+			guard let strongSelf = self else { return }
+			
+			if strongSelf.isPresenting {
+				sheetView.frame.origin.y = UIScreen.main.bounds.size.height-strongSelf.popoverHeight-strongSelf.homeInset
+			} else {
+				sheetView.frame.origin.y = strongSelf.originFrame.origin.y
+			}
+		}, completion: { _ in
+			transitionContext.completeTransition(true)
+		})
+	}
+}


### PR DESCRIPTION
- Instead of using the device name, which is usually left to just "iPhone", I opted to allow the user to input their own display name. The benefits of this include, but are not limited to, better disambiguation of surrounding devices.
- The rules for the display name were selected so as to allow for variable byte-length characters, and to somewhat force the user to identify themselves to surrounding devices.
- I also opted to use UserDefaults here, so as to not add any overhead from Realm or CoreData when it's strictly unnecessary at this point in time.