### PR TITLE
Invite Peer to Chat

### DIFF
--- a/oShare/Constants.swift
+++ b/oShare/Constants.swift
@@ -15,6 +15,7 @@ struct Constants {
 		static let displayNamePopoverTransitionDuration: Double = 0.5
 		static let displayNamePopoverHeight: CGFloat = 300
 		static let standardTableViewRowHeight: CGFloat = 60
+		static let standardInvitationTimeout: TimeInterval = 20
 		
 		// MARK: - Safe Area Insets
 		// These properties will be 0 on non-iPhone X devices, and devices not running iOS 11.

--- a/oShare/MultipeerConnectivityManager.swift
+++ b/oShare/MultipeerConnectivityManager.swift
@@ -54,6 +54,19 @@ class MultipeerConnectivityManager: NSObject {
 		delegate?.stoppedAdvertising()
 	}
 	
+	func invitePeerToChat(peer: MCPeerID) {
+		connectivityBrowser.invitePeer(
+			peer,
+			to: session,
+			withContext: nil,
+			timeout: Constants.Numbers.standardInvitationTimeout
+		)
+	}
+	
+	func respondToInvitation(accepted: Bool) {
+		invitationHandler?(accepted, session)
+	}
+	
 }
 
 extension MultipeerConnectivityManager: MCSessionDelegate {
@@ -105,6 +118,9 @@ extension MultipeerConnectivityManager: MCNearbyServiceBrowserDelegate {
 extension MultipeerConnectivityManager: MCNearbyServiceAdvertiserDelegate {
 
 	func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didReceiveInvitationFromPeer peerID: MCPeerID, withContext context: Data?, invitationHandler: @escaping (Bool, MCSession?) -> Void) {
+		// We're going to ask the user if they'd like to chat with us. So, we'll store this temporarily.
+		self.invitationHandler = invitationHandler
+
 		delegate?.receivedInvitation(fromPeer: peerID, context: context)
 	}
 

--- a/oShare/MultipeerConnectivityManagerDelegate.swift
+++ b/oShare/MultipeerConnectivityManagerDelegate.swift
@@ -26,6 +26,11 @@ protocol MultipeerConnectivityManagerDelegate: class {
 	/// - Parameter peer: the peer who we successfully connected with.
 	func connected(withPeer peer: MCPeerID)
 	
+	/// This function will be triggered whenever we unsuccessfully attempt to connect with a peer.
+	///
+	/// - Parameter peer: the peer who we did not connect with.
+	func failedToConnect(withPeer peer: MCPeerID)
+	
 	/// This function will be triggred whenever we unsuccessfully attempt to browse for peers.
 	func failedToBrowseForPeers(withError error: Error)
 	

--- a/oShare/Peer Browser/PeerBrowserTableViewHandler.swift
+++ b/oShare/Peer Browser/PeerBrowserTableViewHandler.swift
@@ -4,8 +4,9 @@ import MultipeerConnectivity
 
 class PeerBrowserTableViewHandler: NSObject, UITableViewDelegate, UITableViewDataSource {
 	
-	// Pass weak instance of parent table view across. We do not own this reference, so it must be both `weak` and Optional.
+	// Pass weak instance of parent table view, and app delegate across. We do not own these references, so they must be both `weak` and Optional.
 	weak var tableView: UITableView?
+	weak var appDelegate: AppDelegate?
 	
 	// Keep track of the number of peers. Since this is strictly for data display, we don't want to access it outside of this handler.
 	private var foundPeers: [MCPeerID] = []
@@ -45,7 +46,13 @@ class PeerBrowserTableViewHandler: NSObject, UITableViewDelegate, UITableViewDat
 	
 	func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
 		tableView.deselectRow(at: indexPath, animated: true)
-		// TODO: - Invite Peer
+		
+		guard let selectedPeer = appDelegate?.connectivityManager.foundPeers[indexPath.row] else {
+			// TODO: - Handle error should this fail.
+			return
+		}
+		
+		appDelegate?.connectivityManager.invitePeerToChat(peer: selectedPeer)
 	}
 	
 	func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/oShare/Peer Browser/PeerBrowserViewController.swift
+++ b/oShare/Peer Browser/PeerBrowserViewController.swift
@@ -126,21 +126,35 @@ extension PeerBrowserViewController: MultipeerConnectivityManagerDelegate {
 	func receivedInvitation(fromPeer peer: MCPeerID, context: Data?) {
 		let alert = UIAlertController(title: "👋", message: "\(peer.displayName) would like to chat with you!", preferredStyle: UIAlertControllerStyle.alert)
 		let accept: UIAlertAction = UIAlertAction(
-				title: "👍",
+				title: "Sure!",
 				style: UIAlertActionStyle.default
 		) { [weak self] _ -> Void in
 			self?.appDelegate.connectivityManager.respondToInvitation(accepted: true)
 		}
 		
 		let decline = UIAlertAction(
-				title: "👎",
-				style: UIAlertActionStyle.cancel
+				title: "Ignore",
+				style: UIAlertActionStyle.destructive
 		) { [weak self] _ -> Void in
 			self?.appDelegate.connectivityManager.respondToInvitation(accepted: false)
 		}
 		
 		alert.addAction(accept)
 		alert.addAction(decline)
+		
+		OperationQueue.main.addOperation { [weak self] in
+			self?.present(alert, animated: true, completion: nil)
+		}
+	}
+	
+	func failedToConnect(withPeer peer: MCPeerID) {
+		let alert = UIAlertController(title: "😞", message: "Failed to initiate chat session.", preferredStyle: UIAlertControllerStyle.alert)
+		let accept: UIAlertAction = UIAlertAction(
+			title: "OK",
+			style: UIAlertActionStyle.default
+		)
+		
+		alert.addAction(accept)
 		
 		OperationQueue.main.addOperation { [weak self] in
 			self?.present(alert, animated: true, completion: nil)

--- a/oShare/Peer Browser/PeerBrowserViewController.swift
+++ b/oShare/Peer Browser/PeerBrowserViewController.swift
@@ -40,6 +40,8 @@ class PeerBrowserViewController: UIViewController {
 	
 	private func configureHandler() {
 		peerTableViewHandler.tableView = peerTableView
+		peerTableViewHandler.appDelegate = appDelegate
+
 		peerTableView.delegate = peerTableViewHandler
 		peerTableView.dataSource = peerTableViewHandler
 	}
@@ -122,7 +124,27 @@ extension PeerBrowserViewController: MultipeerConnectivityManagerDelegate {
 	}
 
 	func receivedInvitation(fromPeer peer: MCPeerID, context: Data?) {
-		// TODO: - Show Message
+		let alert = UIAlertController(title: "👋", message: "\(peer.displayName) would like to chat with you!", preferredStyle: UIAlertControllerStyle.alert)
+		let accept: UIAlertAction = UIAlertAction(
+				title: "👍",
+				style: UIAlertActionStyle.default
+		) { [weak self] _ -> Void in
+			self?.appDelegate.connectivityManager.respondToInvitation(accepted: true)
+		}
+		
+		let decline = UIAlertAction(
+				title: "👎",
+				style: UIAlertActionStyle.cancel
+		) { [weak self] _ -> Void in
+			self?.appDelegate.connectivityManager.respondToInvitation(accepted: false)
+		}
+		
+		alert.addAction(accept)
+		alert.addAction(decline)
+		
+		OperationQueue.main.addOperation { [weak self] in
+			self?.present(alert, animated: true, completion: nil)
+		}
 	}
 	
 	func connected(withPeer peer: MCPeerID) {


### PR DESCRIPTION
- Send an invite to the chosen peer.
  - This will ask for a response, instead of sending an affirmative response instantly.
- Note that this body of work does not actually invoke nor implement the chat interface.
- Handle the connection response. This was failing as I had a duplicate variable which certain functions read from mistakenly.
- This also works around a strange edge case to do with MPC. **See comments in code.**