### PR TITLE
Tidy Up

### DIFF
--- a/oShare.xcodeproj/project.pbxproj
+++ b/oShare.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		063D1E651FF11ED7001A6DC4 /* CharacterCounterTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063D1E641FF11ED7001A6DC4 /* CharacterCounterTextField.swift */; };
 		063D1E681FF1E922001A6DC4 /* PeerBrowserTableViewHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063D1E671FF1E922001A6DC4 /* PeerBrowserTableViewHandler.swift */; };
 		063D1E6D1FF279B7001A6DC4 /* ChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063D1E6C1FF279B7001A6DC4 /* ChatViewController.swift */; };
+		068F2C0E1FF38AE000EA9D1E /* NSNotificationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068F2C0D1FF38AE000EA9D1E /* NSNotificationExtension.swift */; };
 		06FD152F1FF28F980015E9FD /* ChatTableViewHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FD152E1FF28F980015E9FD /* ChatTableViewHandler.swift */; };
 /* End PBXBuildFile section */
 
@@ -57,6 +58,7 @@
 		063D1E641FF11ED7001A6DC4 /* CharacterCounterTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterCounterTextField.swift; sourceTree = "<group>"; };
 		063D1E671FF1E922001A6DC4 /* PeerBrowserTableViewHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeerBrowserTableViewHandler.swift; sourceTree = "<group>"; };
 		063D1E6C1FF279B7001A6DC4 /* ChatViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewController.swift; sourceTree = "<group>"; };
+		068F2C0D1FF38AE000EA9D1E /* NSNotificationExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSNotificationExtension.swift; sourceTree = "<group>"; };
 		06FD152E1FF28F980015E9FD /* ChatTableViewHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTableViewHandler.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -106,6 +108,7 @@
 				063D1E6A1FF22453001A6DC4 /* MPC */,
 				063D1E691FF2243C001A6DC4 /* Chat Setup */,
 				063D1E6B1FF2795B001A6DC4 /* Chat Screen */,
+				068F2C0C1FF38ACF00EA9D1E /* Extensions */,
 				063D1E661FF1E90A001A6DC4 /* Peer Browser */,
 				063D1E371FEF33FF001A6DC4 /* Main.storyboard */,
 				063D1E3A1FEF33FF001A6DC4 /* Assets.xcassets */,
@@ -168,6 +171,14 @@
 				06FD152E1FF28F980015E9FD /* ChatTableViewHandler.swift */,
 			);
 			path = "Chat Screen";
+			sourceTree = "<group>";
+		};
+		068F2C0C1FF38ACF00EA9D1E /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				068F2C0D1FF38AE000EA9D1E /* NSNotificationExtension.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -284,6 +295,7 @@
 				063D1E5D1FEF3E0D001A6DC4 /* MultipeerConnectivityManagerDelegate.swift in Sources */,
 				063D1E591FEF3C43001A6DC4 /* MultipeerConnectivityError.swift in Sources */,
 				063D1E631FF10F24001A6DC4 /* SheetAnimator.swift in Sources */,
+				068F2C0E1FF38AE000EA9D1E /* NSNotificationExtension.swift in Sources */,
 				063D1E571FEF34A9001A6DC4 /* MultipeerConnectivityManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/oShare/AppDelegate.swift
+++ b/oShare/AppDelegate.swift
@@ -11,11 +11,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 	
 	func configureConnectivityManager() {
 		// Retrieve the display name from UserDefaults, and use that to create our MCPeerID.
-		guard let displayName = UserDefaults.standard.value(forKey: "displayName") as? String, displayName.count > 0 && displayName.count <= 20 else {
-			
-			// If for any reason, the user has somehow set an empty string or a too-long name as their display name, they will be unable to connect to any peers. Handle this error.
-			return
-		}
+		guard let displayName = UserDefaults.standard.value(forKey: "displayName") as? String, displayName.count > 0 && displayName.count <= 20 else { return }
 		
 		connectivityManager = MultipeerConnectivityManager(peer: MCPeerID(displayName: displayName))
 		connectivityManager.startBrowsingForDevices()

--- a/oShare/Base.lproj/Main.storyboard
+++ b/oShare/Base.lproj/Main.storyboard
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="xzB-Qi-Vyj">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="xzB-Qi-Vyj">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -191,9 +191,6 @@
                         <subviews>
                             <navigationBar contentMode="scaleToFill" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XXo-Ww-8Nu">
                                 <rect key="frame" x="0.0" y="20" width="375" height="44"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="44" id="mG5-6X-dag"/>
-                                </constraints>
                                 <items>
                                     <navigationItem title="Set a Display Name" id="OmQ-vL-flT">
                                         <barButtonItem key="rightBarButtonItem" title="Save" id="1w9-ZM-hRZ">
@@ -215,6 +212,12 @@
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="characterLimit">
                                         <integer key="value" value="20"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="paddingFromEdge">
+                                        <real key="value" value="5"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="characterCountLabelWidth">
+                                        <real key="value" value="30"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </textField>

--- a/oShare/Chat Screen/ChatTableViewHandler.swift
+++ b/oShare/Chat Screen/ChatTableViewHandler.swift
@@ -10,6 +10,7 @@ class ChatTableViewHandler: NSObject, UITableViewDelegate, UITableViewDataSource
 	
 	// Keep track of the messages. Since this is strictly for data display, we don't want to access it outside of this handler.
 	private var messages: [Dictionary<String, String>] = []
+	private let messageCellIdentifier: String = "MessageCell"
 	
 	// MARK: - Reloading
 	
@@ -50,13 +51,13 @@ class ChatTableViewHandler: NSObject, UITableViewDelegate, UITableViewDataSource
 	}
 	
 	func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-		let cell = tableView.dequeueReusableCell(withIdentifier: "MessageCell", for: indexPath)
-		let message = messages[indexPath.row]["message"]
-		let sender = messages[indexPath.row]["sender"] ?? Constants.Strings.theySaidString
+		let cell = tableView.dequeueReusableCell(withIdentifier: messageCellIdentifier, for: indexPath)
+		let message = messages[indexPath.row][DictionaryKeys.message.rawValue]
+		let sender = messages[indexPath.row][DictionaryKeys.sender.rawValue] ?? Constants.Strings.theySaidString
 		let senderLabelText: String
 		let senderColor: UIColor
 		
-		if sender == "self" {
+		if sender == Constants.Strings.selfSenderString {
 			senderLabelText = "I said:"
 			senderColor = UIColor.purple
 		} else {
@@ -78,3 +79,7 @@ class ChatTableViewHandler: NSObject, UITableViewDelegate, UITableViewDataSource
 	}
 }
 
+private enum DictionaryKeys: String {
+	case sender
+	case message
+}

--- a/oShare/Chat Screen/ChatTableViewHandler.swift
+++ b/oShare/Chat Screen/ChatTableViewHandler.swift
@@ -79,6 +79,8 @@ class ChatTableViewHandler: NSObject, UITableViewDelegate, UITableViewDataSource
 	}
 }
 
+// MARK: - DictionaryKeys Enum
+
 private enum DictionaryKeys: String {
 	case sender
 	case message

--- a/oShare/Chat Screen/ChatViewController.swift
+++ b/oShare/Chat Screen/ChatViewController.swift
@@ -71,7 +71,7 @@ class ChatViewController: UIViewController {
 	}
 	
 	private func configureEndChatButton() {
-		let endChatButton = UIBarButtonItem(title: "End", style: .done, target: self, action: #selector(self.endChat(sender:)))
+		let endChatButton = UIBarButtonItem(title: Constants.Strings.endButtonString, style: .done, target: self, action: #selector(self.endChat(sender:)))
 		navigationItem.rightBarButtonItem = endChatButton
 	}
 	
@@ -80,14 +80,14 @@ class ChatViewController: UIViewController {
 	@objc private func handleDataReceived(notification: Notification) {
 		guard
 			let object = notification.object as? [String: Any],
-			let data = object["data"] as? Data,
-			let peer = object["peer"] as? MCPeerID,
+			let data = object[DictionaryKeys.data.rawValue] as? Data,
+			let peer = object[DictionaryKeys.peer.rawValue] as? MCPeerID,
 			let message = NSKeyedUnarchiver.unarchiveObject(with: data) as? [String: String]
 			else { return }
 		
-		if let message = message["message"] {
+		if let message = message[DictionaryKeys.message.rawValue] {
 			if message != Constants.Strings.endChatCodeString {
-				let messageDictionary: [String: String] = ["sender": peer.displayName, "message": message]
+				let messageDictionary: [String: String] = [DictionaryKeys.sender.rawValue: peer.displayName, DictionaryKeys.message.rawValue: message]
 				messages.append(messageDictionary)
 				
 				OperationQueue.main.addOperation { [weak self] () -> Void in
@@ -104,7 +104,7 @@ class ChatViewController: UIViewController {
 	
 	private func handleChatEnded(_ peer: MCPeerID) {
 		let alert = UIAlertController(title: "👋", message: "\(peer.displayName) ended the chat.", preferredStyle: .alert)
-		let doneAction: UIAlertAction = UIAlertAction(title: "Close", style: .default) { [weak self] (action) in
+		let doneAction: UIAlertAction = UIAlertAction(title: Constants.Strings.closeButtonString, style: .default) { [weak self] (action) in
 			self?.appDelegate.connectivityManager.session.disconnect()
 			self?.navigationController?.popViewController(animated: true)
 		}
@@ -142,7 +142,7 @@ class ChatViewController: UIViewController {
 	
 	@IBAction private func endChat(sender: UIBarButtonItem?) {
 		// For the sake of simplicity, we are only going to support peer-to-peer chat, as opposed to multiple peers in a single chat. This is why I directly access [0] in the list of connected peers.
-		let messageDictionary: [String: String] = ["sender": "self", "message": Constants.Strings.endChatCodeString]
+		let messageDictionary: [String: String] = [DictionaryKeys.sender.rawValue: Constants.Strings.selfSenderString, DictionaryKeys.message.rawValue: Constants.Strings.endChatCodeString]
 		let waitTimeBeforeDisconnection: TimeInterval = 2
 		
 		guard let connectedPeer = appDelegate.connectivityManager.session.connectedPeers.first else { return }
@@ -167,7 +167,7 @@ class ChatViewController: UIViewController {
 			text.isEmpty == false
 			else { return }
 		
-		let messageData: [String: String] = ["sender": "self", "message": text]
+		let messageData: [String: String] = [DictionaryKeys.sender.rawValue: Constants.Strings.selfSenderString, DictionaryKeys.message.rawValue: text]
 		
 		if appDelegate.connectivityManager.send(dictionaryWithData: messageData, toPeer: peer) {
 			messages.append(messageData)
@@ -190,4 +190,11 @@ extension ChatViewController: UITextFieldDelegate {
 		return true
 	}
 
+}
+
+private enum DictionaryKeys: String {
+	case data
+	case sender
+	case message
+	case peer
 }

--- a/oShare/Chat Screen/ChatViewController.swift
+++ b/oShare/Chat Screen/ChatViewController.swift
@@ -23,6 +23,7 @@ class ChatViewController: UIViewController {
 		configureTableView()
 		configureTextField()
 		configureEndChatButton()
+		configureNavigationBar()
 		registerKeyboardNotifications()
 		registerDataReceivedNotification()
 	}
@@ -47,10 +48,15 @@ class ChatViewController: UIViewController {
 	}
 	
 	private func registerDataReceivedNotification() {
-		NotificationCenter.default.addObserver(self, selector: #selector(self.handleDataReceived(notification:)), name: NSNotification.Name("receivedData"), object: nil)
+		NotificationCenter.default.addObserver(self, selector: #selector(self.handleDataReceived(notification:)), name: NSNotification.Name.oShareRecivedData, object: nil)
 	}
 	
 	// MARK: - UI Configuration
+	
+	private func configureNavigationBar() {
+		guard let peer = appDelegate.connectivityManager.session.connectedPeers.first else { return }
+		navigationItem.title = "\(peer.displayName)"
+	}
 	
 	private func configureTableView() {
 		chatTableViewHandler.appDelegate = appDelegate

--- a/oShare/Chat Screen/ChatViewController.swift
+++ b/oShare/Chat Screen/ChatViewController.swift
@@ -82,10 +82,10 @@ class ChatViewController: UIViewController {
 			let object = notification.object as? [String: Any],
 			let data = object[DictionaryKeys.data.rawValue] as? Data,
 			let peer = object[DictionaryKeys.peer.rawValue] as? MCPeerID,
-			let message = NSKeyedUnarchiver.unarchiveObject(with: data) as? [String: String]
+			let messageData = NSKeyedUnarchiver.unarchiveObject(with: data) as? [String: String]
 			else { return }
 		
-		if let message = message[DictionaryKeys.message.rawValue] {
+		if let message = messageData[DictionaryKeys.message.rawValue] {
 			if message != Constants.Strings.endChatCodeString {
 				let messageDictionary: [String: String] = [DictionaryKeys.sender.rawValue: peer.displayName, DictionaryKeys.message.rawValue: message]
 				messages.append(messageDictionary)
@@ -138,7 +138,7 @@ class ChatViewController: UIViewController {
 		}
 	}
 	
-	// MARK: - End Chat
+	// MARK: - Call To Action (End Chat)
 	
 	@IBAction private func endChat(sender: UIBarButtonItem?) {
 		// For the sake of simplicity, we are only going to support peer-to-peer chat, as opposed to multiple peers in a single chat. This is why I directly access [0] in the list of connected peers.
@@ -157,7 +157,7 @@ class ChatViewController: UIViewController {
 		}
 	}
 	
-	// MARK: - Send Message
+	// MARK: - Call To Action (Send Message)
 	
 	@IBAction private func sendMessage(sender: UIButton?) {
 		// Only proceed sending data if the text is not empty, and if there is still a connected peer.
@@ -181,6 +181,8 @@ class ChatViewController: UIViewController {
 	
 }
 
+// MARK: - UITextFieldDelegate
+
 extension ChatViewController: UITextFieldDelegate {
 
 	func textFieldShouldReturn(_ textField: UITextField) -> Bool {
@@ -191,6 +193,8 @@ extension ChatViewController: UITextFieldDelegate {
 	}
 
 }
+
+// MARK: - DictionaryKeys Enum
 
 private enum DictionaryKeys: String {
 	case data

--- a/oShare/Chat Setup/CharacterCounterTextField.swift
+++ b/oShare/Chat Setup/CharacterCounterTextField.swift
@@ -4,13 +4,24 @@ import UIKit
 @IBDesignable class CharacterCounterTextField: UITextField {
 	
 	@IBInspectable var characterLimit: Int = 20
+	@IBInspectable var paddingFromEdge: CGFloat = 5
+	@IBInspectable var characterCountLabelWidth: CGFloat = 30
 	
-	private let characterCountLabel = UILabel()
-	private let characterCountLabelSize: CGSize = CGSize(width: 30, height: 30)
-	private let characterCountLabelXOffset: CGFloat = 35
+	private var characterCountLabel = UILabel()
+	private var characterCountLabelSize: CGSize = .zero
+	private var characterCountLabelXOffset: CGFloat = 0
 	
 	override func awakeFromNib() {
 		super.awakeFromNib()
+		
+		// The height of the character counting label should always be the height of the parent text field.
+		characterCountLabelSize.height = frame.size.height
+		
+		// Assign the width predetermined in Interface Builder. Otherwise use the default value.
+		characterCountLabelSize.width = characterCountLabelWidth
+		
+		// Apply the offset from the edge of the view. This can be left, or right.
+		characterCountLabelXOffset = characterCountLabelWidth+paddingFromEdge
 		
 		if characterLimit > 0 {
 			setCountLabel()
@@ -22,6 +33,7 @@ import UIKit
 		characterCountLabel.textAlignment = .center
 		characterCountLabel.text = "0"
 		
+		// Assumption that the supplementary view will always be on the right. This can be changed to `left` if needed.
 		rightView = characterCountLabel
 		rightViewMode = .always
 	}
@@ -30,13 +42,16 @@ import UIKit
 		characterCountLabel.text = "\(count)"
 		
 		if count > Constants.Numbers.maximumDisplayNameLength || count == 0 {
+			// Indicate to the user that this is VERY BAD (i.e. not allowed).
 			characterCountLabel.textColor = .red
 		} else {
+			// If the count is within the limit, indicate that it's OK by remaining black.
 			characterCountLabel.textColor = .black
 		}
 	}
 	
 	override func rightViewRect(forBounds bounds: CGRect) -> CGRect {
+		// Assumption that the supplementary view will always be on the right. This can be changed to `frame.origin.x+padding` if needed.
 		if characterLimit > 0 {
 			return CGRect(
 				origin: CGPoint(x: frame.width-characterCountLabelXOffset, y: 0),

--- a/oShare/Chat Setup/ChatSetupViewController.swift
+++ b/oShare/Chat Setup/ChatSetupViewController.swift
@@ -11,13 +11,17 @@ class ChatSetupViewController: UIViewController {
 	@IBOutlet var displayNameTextField: CharacterCounterTextField!
 	@IBOutlet var continueButton: UIBarButtonItem!
 	
+	// A delegate declaration should always be `weak` and Optional, so as to avoid reference cycles.
 	weak var delegate: ChatSetupViewControllerDelegate?
 	
 	required init?(coder aDecoder: NSCoder) {
 		super.init(coder: aDecoder)
 		
+		// To display this "partially" over the previous view controller, this needs to be set to prevent the "origin" (during presentation) and "destination" (during dismissal) from being removed.
 		modalPresentationStyle = .overCurrentContext
 	}
+	
+	// MARK: - View Lifecycle
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
@@ -37,6 +41,8 @@ class ChatSetupViewController: UIViewController {
 		NotificationCenter.default.removeObserver(self)
 	}
 	
+	// MARK: - UI Configuration
+	
 	private func configureSaveButton() {
 		continueButton.isEnabled = false
 	}
@@ -52,6 +58,15 @@ class ChatSetupViewController: UIViewController {
 			continueButton.isEnabled = true
 		}
 	}
+	
+	private func updateCharacterCountLabel(withCount count: Int) {
+		// The MCPeerID documentation states that the hard limit for display names is 63 bytes in UTF-8 encoding. I could set the limit to 63 characters, however a user may be partial to using Emoji, or may use a language such as 日本語, which characters have a variable byte length. 20 seems like a safe value here.
+		
+		continueButton.isEnabled = count <= Constants.Numbers.maximumDisplayNameLength && count > 0
+		displayNameTextField.updateWith(count: count)
+	}
+	
+	// MARK: - Notifications
 	
 	private func registerKeyboardNotifications() {
 		NotificationCenter.default.addObserver(self, selector: #selector(ChatSetupViewController.adjustForDisplayKeyboard(_:)), name: NSNotification.Name.UIKeyboardWillShow, object: nil)
@@ -75,6 +90,8 @@ class ChatSetupViewController: UIViewController {
 			}
 	}
 	
+	// MARK: - Call To Action (Save Name)
+	
 	@IBAction private func saveDisplayName(sender: UIButton) {
 		guard let displayName = displayNameTextField.text, displayNameTextField.text?.isEmpty == false else { return }
 		
@@ -87,14 +104,9 @@ class ChatSetupViewController: UIViewController {
 		})
 	}
 	
-	private func updateCharacterCountLabel(withCount count: Int) {
-		// The MCPeerID documentation states that the hard limit for display names is 63 bytes in UTF-8 encoding. I could set the limit to 63 characters, however a user may be partial to using Emoji, or may use a language such as 日本語, which characters have a variable byte length. 20 seems like a safe value here.
-		
-		continueButton.isEnabled = count <= Constants.Numbers.maximumDisplayNameLength && count > 0
-		displayNameTextField.updateWith(count: count)
-	}
-	
 }
+
+// MARK: - UITextFieldDelegate
 
 extension ChatSetupViewController: UITextFieldDelegate {
 	func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {

--- a/oShare/Chat Setup/ChatSetupViewController.swift
+++ b/oShare/Chat Setup/ChatSetupViewController.swift
@@ -8,8 +8,8 @@ protocol ChatSetupViewControllerDelegate: class {
 class ChatSetupViewController: UIViewController {
 
 	// As per recent WWDC sessions, IBOutlet properties should be `strong`. I generally prefer to keep them `weak` as old habits die hard, however for standards sake, I'll keep them strong.
-	@IBOutlet var displayNameTextField: CharacterCounterTextField!
-	@IBOutlet var continueButton: UIBarButtonItem!
+	@IBOutlet private var displayNameTextField: CharacterCounterTextField!
+	@IBOutlet private var continueButton: UIBarButtonItem!
 	
 	// A delegate declaration should always be `weak` and Optional, so as to avoid reference cycles.
 	weak var delegate: ChatSetupViewControllerDelegate?

--- a/oShare/Chat Setup/SheetAnimator.swift
+++ b/oShare/Chat Setup/SheetAnimator.swift
@@ -1,6 +1,8 @@
 import UIKit
 import Foundation
 
+// I decided to invoke this brilliant little protocol so as to only occupy as much of the screen as used by the view controller.
+
 class SheetAnimator: NSObject, UIViewControllerAnimatedTransitioning {
 	
 	var isPresenting = true
@@ -21,7 +23,8 @@ class SheetAnimator: NSObject, UIViewControllerAnimatedTransitioning {
 		let containerView = transitionContext.containerView
 		let bottomInset = Constants.appDelegate?.window?.safeAreaInsets.bottom ?? 0
 		
-		// We want to ensure we actually have a destination.
+		// We want to ensure we actually have a destination, before performing any animation.
+		// This should always evaluate to true, however the properties return as Optional by default and so need to be unwrapped.
 		guard let sheetView = isPresenting ? transitionContext.view(forKey: .to) : transitionContext.view(forKey: .from) else { return }
 		
 		popoverHeight = sheetView.systemLayoutSizeFitting(CGSize(width: UIScreen.main.bounds.size.width, height: 100), withHorizontalFittingPriority: .required, verticalFittingPriority: .defaultLow).height

--- a/oShare/Constants.swift
+++ b/oShare/Constants.swift
@@ -12,6 +12,8 @@ struct Constants {
 		static let endChatCodeString: String = "_end_chat_"
 		static let theySaidString: String = "They"
 		static let selfSenderString: String = "self"
+		static let closeButtonString: String = "Close"
+		static let endButtonString: String = "End"
 	}
 	
 	struct Numbers {

--- a/oShare/Extensions/NSNotificationExtension.swift
+++ b/oShare/Extensions/NSNotificationExtension.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 
+// Define the custom NSNotification into an extension on `.Name` to avoid using the "Stringly-Typed" API for non-predefined notifications.
 public extension NSNotification.Name {
 	public static let oShareRecivedData = NSNotification.Name("receivedData")
 }

--- a/oShare/Extensions/NSNotificationExtension.swift
+++ b/oShare/Extensions/NSNotificationExtension.swift
@@ -1,0 +1,6 @@
+import Foundation
+import UIKit
+
+public extension NSNotification.Name {
+	public static let oShareRecivedData = NSNotification.Name("receivedData")
+}

--- a/oShare/MPC/MultipeerConnectivityManager.swift
+++ b/oShare/MPC/MultipeerConnectivityManager.swift
@@ -98,7 +98,8 @@ extension MultipeerConnectivityManager: MCSessionDelegate {
 
 			delegate?.connected(withPeer: peerID)
 		case .connecting:
-			// TODO: - Display Indicator?
+			// In most cases tested, "connecting" only lasts for a split second, or a couple of seconds.
+			// As such, I decided to not implement a loading indicator.
 			break
 		default: break
 		}
@@ -106,19 +107,19 @@ extension MultipeerConnectivityManager: MCSessionDelegate {
 	
 	func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
 		let dictionary: [String: Any] = ["data": data, "peer": peerID]
-		NotificationCenter.default.post(name: NSNotification.Name("receivedData"), object: dictionary)
+		NotificationCenter.default.post(name: NSNotification.Name.oShareRecivedData, object: dictionary)
 	}
 	
 	func session(_ session: MCSession, didReceive stream: InputStream, withName streamName: String, fromPeer peerID: MCPeerID) {
-		// TODO: - Handle in next commits
+		// Not implemented. Delegate method required.
 	}
 	
 	func session(_ session: MCSession, didStartReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, with progress: Progress) {
-		// TODO: - Handle in next commits
+		// Not implemented. Delegate method required.
 	}
 	
 	func session(_ session: MCSession, didFinishReceivingResourceWithName resourceName: String, fromPeer peerID: MCPeerID, at localURL: URL?, withError error: Error?) {
-		// TODO: - Handle in next commits
+		// Not implemented. Delegate method required.
 	}
 
 	func session(_ session: MCSession, didReceiveCertificate certificate: [Any]?, fromPeer peerID: MCPeerID, certificateHandler: @escaping (Bool) -> Void) {
@@ -131,14 +132,14 @@ extension MultipeerConnectivityManager: MCSessionDelegate {
 extension MultipeerConnectivityManager: MCNearbyServiceBrowserDelegate {
 
 	func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String : String]?) {
-		guard peerID != localPeer, foundPeers.contains(peerID) == false else { return }
+		guard foundPeers.contains(peerID) == false else { return }
 
 		foundPeers.append(peerID)
 		delegate?.foundPeer(peerID)
 	}
 
 	func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
-		foundPeers = foundPeers.filter({ $0.displayName != peerID.displayName })
+		foundPeers = foundPeers.filter({ $0 != peerID })
 		delegate?.lostPeer(peerID)
 	}
 

--- a/oShare/MPC/MultipeerConnectivityManager.swift
+++ b/oShare/MPC/MultipeerConnectivityManager.swift
@@ -10,8 +10,9 @@ class MultipeerConnectivityManager: NSObject {
 
 	private var connectivityBrowser: MCNearbyServiceBrowser
 	private var connectivityAdvertiser: MCNearbyServiceAdvertiser
-	
 	private(set) var session: MCSession
+	
+	// MARK: - Initialization
 	
 	init(peer: MCPeerID) {
 		self.localPeer = peer
@@ -34,6 +35,8 @@ class MultipeerConnectivityManager: NSObject {
 		self.connectivityAdvertiser.delegate = self
 		self.connectivityBrowser.delegate = self
 	}
+	
+	// MARK: - Helper Functions
 	
 	func startBrowsingForDevices() {
 		connectivityBrowser.startBrowsingForPeers()
@@ -65,8 +68,11 @@ class MultipeerConnectivityManager: NSObject {
 	}
 	
 	func respondToInvitation(accepted: Bool) {
+		// Trigger the invitation callback with our response.
 		invitationHandler?(accepted, session)
 	}
+	
+	// MARK: - Send Data
 	
 	func send(dictionaryWithData dictionary: [String: String], toPeer targetPeer: MCPeerID) -> Bool {
 		let dataToSend = NSKeyedArchiver.archivedData(withRootObject: dictionary)
@@ -86,6 +92,7 @@ class MultipeerConnectivityManager: NSObject {
 extension MultipeerConnectivityManager: MCSessionDelegate {
 	
 	func browser(_ browser: MCNearbyServiceBrowser, didNotStartBrowsingForPeers error: Error) {
+		// In the event we failed to browse for nearby people, we should let the user know.
 		delegate?.failedToBrowseForPeers(withError: error)
 	}
 	
@@ -98,7 +105,7 @@ extension MultipeerConnectivityManager: MCSessionDelegate {
 
 			delegate?.connected(withPeer: peerID)
 		case .connecting:
-			// In most cases tested, "connecting" only lasts for a split second, or a couple of seconds.
+			// In most cases tested, "connecting" only lasts for a split second, or a couple of seconds at worst.
 			// As such, I decided to not implement a loading indicator.
 			break
 		default: break
@@ -106,7 +113,9 @@ extension MultipeerConnectivityManager: MCSessionDelegate {
 	}
 	
 	func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
-		let dictionary: [String: Any] = ["data": data, "peer": peerID]
+		// Assemble a dictionary with the data received. I opted to use a dictionary in order to namespace the objects.
+
+		let dictionary: [String: Any] = [DictionaryKeys.data.rawValue: data, DictionaryKeys.peer.rawValue: peerID]
 		NotificationCenter.default.post(name: NSNotification.Name.oShareRecivedData, object: dictionary)
 	}
 	
@@ -124,34 +133,51 @@ extension MultipeerConnectivityManager: MCSessionDelegate {
 
 	func session(_ session: MCSession, didReceiveCertificate certificate: [Any]?, fromPeer peerID: MCPeerID, certificateHandler: @escaping (Bool) -> Void) {
 		// For the sake of simplicity, I am responding `true` for all cases here.
+		// It simply sends acknowledgement that contact was made. If I return false here, or ignore it, the connection does not succeed.
 		certificateHandler(true)
 	}
 
 }
 
+// MARK: - MCNearbyServiceBrowserDelegate
+
 extension MultipeerConnectivityManager: MCNearbyServiceBrowserDelegate {
 
 	func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String : String]?) {
+		// Make sure that we don't re-add the same peer.
 		guard foundPeers.contains(peerID) == false else { return }
 
+		// Make sure ourselves don't appear in the list, even for a second.
+		// This seemed to happen on iOS 11.2, but not in 11.2.1. Better safe than sorry.
+		foundPeers = foundPeers.filter { $0 != localPeer }
 		foundPeers.append(peerID)
 		delegate?.foundPeer(peerID)
 	}
 
 	func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
-		foundPeers = foundPeers.filter({ $0 != peerID })
+		foundPeers = foundPeers.filter { $0 != peerID && $0 != localPeer }
 		delegate?.lostPeer(peerID)
 	}
 
 }
 
+// MARK: - MCNearbyServiceAdvertiserDelegate
+
 extension MultipeerConnectivityManager: MCNearbyServiceAdvertiserDelegate {
 
 	func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didReceiveInvitationFromPeer peerID: MCPeerID, withContext context: Data?, invitationHandler: @escaping (Bool, MCSession?) -> Void) {
-		// We're going to ask the user if they'd like to chat with us. So, we'll store this temporarily.
-		self.invitationHandler = invitationHandler
 
+		// We're going to ask the user if they'd like to chat with us. So, we'll store this temporarily.
+
+		self.invitationHandler = invitationHandler
 		delegate?.receivedInvitation(fromPeer: peerID, context: context)
 	}
 
+}
+
+// MARK: - DictionaryKeys Enum
+
+private enum DictionaryKeys: String {
+	case peer
+	case data
 }

--- a/oShare/MPC/MultipeerConnectivityManagerDelegate.swift
+++ b/oShare/MPC/MultipeerConnectivityManagerDelegate.swift
@@ -33,17 +33,5 @@ protocol MultipeerConnectivityManagerDelegate: class {
 	
 	/// This function will be triggred whenever we unsuccessfully attempt to browse for peers.
 	func failedToBrowseForPeers(withError error: Error)
-	
-	/// This function will be triggered whenever we start advertising ourselves to nearby peers.
-	func beganAdvertising()
-	
-	/// This function will be triggered whenever we stop advertising ourselves to nearby peers.
-	func stoppedAdvertising()
-	
-	/// This function will be triggered whenever we start browsing for nearby peers.
-	func beganBrowsing()
-	
-	/// This function will be triggered whenever we stop browsing for nearby peers.
-	func stoppedBrowsing()
 
 }

--- a/oShare/Peer Browser/PeerBrowserTableViewHandler.swift
+++ b/oShare/Peer Browser/PeerBrowserTableViewHandler.swift
@@ -10,6 +10,7 @@ class PeerBrowserTableViewHandler: NSObject, UITableViewDelegate, UITableViewDat
 	
 	// Keep track of the number of peers. Since this is strictly for data display, we don't want to access it outside of this handler.
 	private var foundPeers: [MCPeerID] = []
+	private let peerCellIdentifier: String = "PeerCell"
 	
 	// Some example status messages. Theoretically, a user could set this in their app preferences, to advertise their current status to their team. I shamelessly ripped this idea from WhatsApp, Slack and Skype.
 	// Because these messages are accessed randomly, an extremely large font size in Settings can result in the messages changing upon scroll. A full-fledged implementation would not have this issue.
@@ -47,16 +48,12 @@ class PeerBrowserTableViewHandler: NSObject, UITableViewDelegate, UITableViewDat
 	func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
 		tableView.deselectRow(at: indexPath, animated: true)
 		
-		guard let selectedPeer = appDelegate?.connectivityManager.foundPeers[indexPath.row] else {
-			// TODO: - Handle error should this fail.
-			return
-		}
-		
+		guard let selectedPeer = appDelegate?.connectivityManager.foundPeers[indexPath.row] else { return }
 		appDelegate?.connectivityManager.invitePeerToChat(peer: selectedPeer)
 	}
 	
 	func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-		let cell = tableView.dequeueReusableCell(withIdentifier: "PeerCell", for: indexPath)
+		let cell = tableView.dequeueReusableCell(withIdentifier: peerCellIdentifier, for: indexPath)
 		let randomIndex = Int(arc4random_uniform(UInt32(exampleStatusMessages.count)))
 		
 		cell.textLabel?.font = UIFont.preferredFont(forTextStyle: .title3)

--- a/oShare/Peer Browser/PeerBrowserViewController.swift
+++ b/oShare/Peer Browser/PeerBrowserViewController.swift
@@ -3,12 +3,11 @@ import MultipeerConnectivity
 
 class PeerBrowserViewController: UIViewController {
 	
-	@IBOutlet var peerTableView: UITableView!
-	@IBOutlet var discoverabilitySwitch: UISwitch!
+	@IBOutlet private var peerTableView: UITableView!
+	@IBOutlet private var discoverabilitySwitch: UISwitch!
 	
 	private let transitionAnimator = SheetAnimator()
 	private let peerTableViewHandler = PeerBrowserTableViewHandler()
-	private var isAdvertising = true
 	private var appDelegate: AppDelegate!
 	
 	// MARK: - View Lifecycle
@@ -36,7 +35,7 @@ class PeerBrowserViewController: UIViewController {
 		NotificationCenter.default.removeObserver(self)
 	}
 	
-	// MARK: - Configuration
+	// MARK: - UI Configuration
 	
 	private func addDynamicTextObservers() {
 		NotificationCenter.default.addObserver(self, selector: #selector(self.handleDynamicTextChanges(notification:)), name: NSNotification.Name.UIContentSizeCategoryDidChange, object: nil)
@@ -108,23 +107,9 @@ extension PeerBrowserViewController: ChatSetupViewControllerDelegate {
 	}
 }
 
+// MARK: - MultipeerConnectivityManagerDelegate
+
 extension PeerBrowserViewController: MultipeerConnectivityManagerDelegate {
-	
-	func beganBrowsing() {
-		
-	}
-	
-	func beganAdvertising() {
-		isAdvertising = true
-	}
-	
-	func stoppedBrowsing() {
-		
-	}
-	
-	func stoppedAdvertising() {
-		isAdvertising = false
-	}
 
 	func receivedInvitation(fromPeer peer: MCPeerID, context: Data?) {
 		let alert = UIAlertController(title: "👋", message: "\(peer.displayName) would like to chat with you!", preferredStyle: UIAlertControllerStyle.alert)

--- a/oShare/Peer Browser/PeerBrowserViewController.swift
+++ b/oShare/Peer Browser/PeerBrowserViewController.swift
@@ -20,6 +20,10 @@ class PeerBrowserViewController: UIViewController {
 		
 		guard let appDelegate = Constants.appDelegate else { return }
 		self.appDelegate = appDelegate
+	}
+	
+	override func viewWillAppear(_ animated: Bool) {
+		super.viewWillAppear(animated)
 		
 		addDynamicTextObservers()
 		checkDisplayName()
@@ -41,7 +45,6 @@ class PeerBrowserViewController: UIViewController {
 	private func configureHandler() {
 		peerTableViewHandler.tableView = peerTableView
 		peerTableViewHandler.appDelegate = appDelegate
-
 		peerTableView.delegate = peerTableViewHandler
 		peerTableView.dataSource = peerTableViewHandler
 	}


### PR DESCRIPTION
- Define all "Stringly-Typed" Keys used in Dictionary objects into enums, which are scope-limited to the files they reside in.
- Remove all instances of static strings where appropriate, defining them in one place and accessing them from there.
- Add comments where appropriate.
- Define and clarify any assumptions (UITextField extension) made.
- Scope-limit any IBOutlets.

(NOTE: I seemed to get a number of IBInspectable crashes when I defined the variables as `private`. Leaving them as `var` (aka `internal`) seemed to avoid it. **sigh**